### PR TITLE
A problem with thumbnails is solved for GetVideo method. 

### DIFF
--- a/VimeoDotNet/VimeoDotNet.Tests/VimeoClient_IntegrationTests.cs
+++ b/VimeoDotNet/VimeoDotNet.Tests/VimeoClient_IntegrationTests.cs
@@ -145,6 +145,7 @@ namespace VimeoDotNet.Tests
 
             // assert
             Assert.IsNotNull(video);
+            Assert.IsTrue(video.pictures.Any(a=>a.uri!=null));
         }
 
         [TestMethod]

--- a/VimeoDotNet/VimeoDotNet/Constants/ApiVersions.cs
+++ b/VimeoDotNet/VimeoDotNet/Constants/ApiVersions.cs
@@ -5,5 +5,6 @@
         public const string v2_0 = "version=2.0";
         public const string v2_5 = "version=2.5";
         public const string v3_0 = "version=3.0";
+        public const string v3_2 = "version=3.2";
     }
 }

--- a/VimeoDotNet/VimeoDotNet/Constants/Request.cs
+++ b/VimeoDotNet/VimeoDotNet/Constants/Request.cs
@@ -9,7 +9,7 @@ namespace VimeoDotNet.Constants
         public const string HeaderContentType = "Content-Type";
         public const string HeaderContentLength = "Content-Length";
         public const string HeaderContentRange = "Content-Range";
-        public const string HeaderAccepts = "Accepts";
+        public const string HeaderAccepts = "Accept";
 
         public const string DefaultProtocol = ProtocolHttps;
         public const string DefaultHostName = "api.vimeo.com";

--- a/VimeoDotNet/VimeoDotNet/Net/ApiRequest.cs
+++ b/VimeoDotNet/VimeoDotNet/Net/ApiRequest.cs
@@ -90,7 +90,7 @@ namespace VimeoDotNet.Net
             Port = Request.DefaultHttpsPort;
             Method = Request.DefaultMethod;
             ResponseType = ResponseTypes.Wildcard;
-            ApiVersion = ApiVersions.v3_0;
+            ApiVersion = ApiVersions.v3_2;
             ExcludeAuthorizationHeader = false;
         }
 
@@ -294,7 +294,7 @@ namespace VimeoDotNet.Net
             Protocol = string.IsNullOrWhiteSpace(Protocol) ? Request.DefaultProtocol : Protocol;
             Host = string.IsNullOrWhiteSpace(Host) ? Request.DefaultHostName : Host;
             ResponseType = string.IsNullOrWhiteSpace(ResponseType) ? ResponseTypes.Wildcard : ResponseType;
-            ApiVersion = string.IsNullOrWhiteSpace(ApiVersion) ? ApiVersions.v3_0 : ApiVersion;
+            ApiVersion = string.IsNullOrWhiteSpace(ApiVersion) ? ApiVersions.v3_2 : ApiVersion;
 
             Protocol = Protocol.ToLower();
             Host = Host.ToLower();


### PR DESCRIPTION
A problem with thumbnails is solved for GetVideo method. From email to vimeo support: "The pictures field was updated in 3.2, and the playground uses that same version."
A new version (3.2) is introduced and set as a default
Name of the header is 'Accept' instead of 'Accepts'.

I did this changes in order to get thumbnails for uploaded video. This was my email to vimeo
Hello vimeo,

I've got a small problem with API, hope you can help me to solve it. I use https://github.com/scommisso/vimeo-dot-net library to make API calls. I do regular 'get video' call like https://api.vimeo.com/videos/121985191 . The problem is that if I do the same call from the sandbox the format of pictures is "pictures": {
"uri": "/videos/121985191/pictures/510627107",
"active": true,
"sizes": [
{
"width": 100,
"height": 75,
"link": "https://i.vimeocdn.com/video/510627107_100x75.jpg"
},
{
"width": 200,
"height": 150,
"link": "https://i.vimeocdn.com/video/510627107_200x150.jpg"
},
{
"width": 295,
"height": 166,
"link": "https://i.vimeocdn.com/video/510627107_295x166.jpg"
},
{
"width": 640,
"height": 360,
"link": "https://i.vimeocdn.com/video/510627107_640x360.jpg"
},
{
"width": 960,
"height": 540,
"link": "https://i.vimeocdn.com/video/510627107_960x540.jpg"
},
{
"width": 1280,
"height": 720,
"link": "https://i.vimeocdn.com/video/510627107_1280x720.jpg"
}
]
}, so it is one object with array of sizes and when I do the same from the library I get them in the following format pictures":[{"type":"thumbnail","width":1280,"height":720,"link":"https://i.vimeocdn.com/video/510627107_1280.jpg"},{"type":"thumbnail","width":960,"height":540,"link":"https://i.vimeocdn.com/video/510627107_960.jpg"},{"type":"thumbnail","width":640,"height":360,"link":"https://i.vimeocdn.com/video/510627107_640.jpg"},{"type":"thumbnail","width":295,"height":166,"link":"https://i.vimeocdn.com/video/510627107_295x166.jpg"},{"type":"thumbnail","width":200,"height":150,"link":"https://i.vimeocdn.com/video/510627107_200x150.jpg"},{"type":"thumbnail","width":100,"height":75,"link":"https://i.vimeocdn.com/video/510627107_100x75.jpg"}]. So it is an array. I believe that there is something related to versions of your API. Can you please tell me what version is correct and what shall I do to be complained with the latest version?
